### PR TITLE
Update INSTALL to have instructions for mac

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -11,6 +11,7 @@ Contents:
 2 Unix/Linux: pkg-config
 3 Unix/Linux: runtime linkage
 4 Unix/Linux: legacy configuration
+5 Mac: `brew install jags`
 
 1 Windows
 ---------
@@ -204,3 +205,8 @@ session, using the configure.args argument:
 
 If configure arguments are set, they always override the corresponding
 environment variables.
+
+2 Mac (OS X): `brew install jags`
+------------------------
+
+You can use [homebrew](https://brew.sh/) to install [jags](https://formulae.brew.sh/formula/jags) via the command `brew install jags`. You can also download the file [directly from sourceforge[(https://sourceforge.net/projects/mcmc-jags/files/).

--- a/INSTALL
+++ b/INSTALL
@@ -209,4 +209,4 @@ environment variables.
 2 Mac (OS X): `brew install jags`
 ------------------------
 
-You can use [homebrew](https://brew.sh/) to install [jags](https://formulae.brew.sh/formula/jags) via the command `brew install jags`. You can also download the file [directly from sourceforge[(https://sourceforge.net/projects/mcmc-jags/files/).
+You can use [homebrew](https://brew.sh/) to install [jags](https://formulae.brew.sh/formula/jags) via the command `brew install jags`. You can also download the file [directly from [sourceforge[(https://sourceforge.net/projects/mcmc-jags/files/).

--- a/INSTALL
+++ b/INSTALL
@@ -209,4 +209,4 @@ environment variables.
 2 Mac (OS X): `brew install jags`
 ------------------------
 
-You can use [homebrew](https://brew.sh/) to install [jags](https://formulae.brew.sh/formula/jags) via the command `brew install jags`. You can also download the file [directly from [sourceforge[(https://sourceforge.net/projects/mcmc-jags/files/).
+You can use [homebrew](https://brew.sh/) to install [jags](https://formulae.brew.sh/formula/jags) via the command `brew install jags`. You can also download the file [directly from [sourceforge](https://sourceforge.net/projects/mcmc-jags/files/).


### PR DESCRIPTION
I tried to install `RoBMA` and when it tried to install `rjags` as a dependency, I got the message: 
`configure: error: "automatic detection of JAGS failed. Please use pkg-config to locate the JAGS library. See the INSTALL file for details."` 

Putting aside the fact that I don't use Linux, so pkg-config isn't relevant -- the `INSTALL` file has no mac instructions 😃 so I added some